### PR TITLE
feat: add post requests to qwacker api

### DIFF
--- a/src/components/cards/write-card.tsx
+++ b/src/components/cards/write-card.tsx
@@ -27,7 +27,12 @@ export enum WriteCardVariant {
   main = 'main', // todo: besserer Name wie main für die Variant finden
 }
 
+// todo: eigene Typen
+// todo: Frage: Ist ein Context für die Übergabe des States schöner?
 type WriteCardProps = {
+  form?: {
+    text: string;
+  };
   variant: WriteCardVariant;
   handleChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
@@ -50,7 +55,7 @@ const writeCardVariantMap: Record<WriteCardVariant, WriteCardVariantMap> = {
 };
 
 //TODO Form handling und Bildupload-Modal integration
-export const WriteCard: FC<WriteCardProps> = ({ variant, handleChange, handleSubmit }) => {
+export const WriteCard: FC<WriteCardProps> = ({ form, variant, handleChange, handleSubmit }) => {
   const settings = writeCardVariantMap[variant] || writeCardVariantMap.inline;
   const { data: session } = useSession();
 
@@ -88,31 +93,31 @@ export const WriteCard: FC<WriteCardProps> = ({ variant, handleChange, handleSub
               placeholder="Und was meinst du dazu?"
               required
               rows={5}
-              value=""
+              value={form?.text || ''}
             />
-          </Form>
 
-          <Stack spacing={StackSpacing.s}>
-            <TextButton
-              color={TextButtonColor.slate}
-              displayMode={TextButtonDisplayMode.fullWidth}
-              icon={<IconUpload />}
-              onClick={() => console.log('bild upload click')}
-              size={TextButtonSize.m}
-            >
-              Bild hochladen
-            </TextButton>
-            <TextButton
-              color={TextButtonColor.violet}
-              displayMode={TextButtonDisplayMode.fullWidth}
-              icon={<IconUpload />}
-              onClick={() => console.log('absenden click')}
-              size={TextButtonSize.m}
-              type="submit"
-            >
-              Absenden
-            </TextButton>
-          </Stack>
+            <Stack spacing={StackSpacing.s}>
+              <TextButton
+                color={TextButtonColor.slate}
+                displayMode={TextButtonDisplayMode.fullWidth}
+                icon={<IconUpload />}
+                onClick={() => console.log('bild upload click')}
+                size={TextButtonSize.m}
+              >
+                Bild hochladen
+              </TextButton>
+              <TextButton
+                color={TextButtonColor.violet}
+                displayMode={TextButtonDisplayMode.fullWidth}
+                icon={<IconUpload />}
+                onClick={() => console.log('absenden click')}
+                size={TextButtonSize.m}
+                type="submit"
+              >
+                Absenden
+              </TextButton>
+            </Stack>
+          </Form>
         </Stack>
       </Card>
     )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,10 +18,10 @@ import Head from 'next/head';
 import { MumbleCard, MumbleCardVariant } from '../components/cards/mumble-card';
 import { Mumble } from '../types/mumble';
 import { WriteCard, WriteCardVariant } from '../components/cards/write-card';
-import { fetchMumbles } from '../services/qwacker-api/posts';
+import { fetchMumbles, postMumble } from '../services/qwacker-api/posts';
 import { getToken } from 'next-auth/jwt';
 import { useSession } from 'next-auth/react';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 type PageProps = {
   count: number;
@@ -40,6 +40,23 @@ export default function PageHome({
   const [hasMore, setHasMore] = useState(initialMumbles.length < count);
 
   const { data: session } = useSession();
+
+  const [form, setForm] = useState({
+    text: '',
+  });
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({
+      ...form,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const handleSubmit = async () => {
+    const newMumble = await postMumble(form.text, null, session?.accessToken as string);
+    console.warn('handleSubmit', newMumble);
+    // todo: update state
+  };
 
   const loadMore = async () => {
     const { count, mumbles: newMumbles } = await fetchMumbles({
@@ -70,11 +87,13 @@ export default function PageHome({
         <Stack direction={StackDirection.col} spacing={StackSpacing.s} withDivider={true}>
           <>
             {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+            {/* STATE AKTUALISIEREN UND PROXY API CALL*/}
             {session && (
               <WriteCard
+                form={form}
                 variant={WriteCardVariant.main}
-                handleChange={() => console.log('click')}
-                handleSubmit={() => console.log('click')}
+                handleChange={handleChange}
+                handleSubmit={handleSubmit}
               />
             )}
             {mumbles.map((mumble) => (

--- a/src/services/qwacker-api/api.ts
+++ b/src/services/qwacker-api/api.ts
@@ -1,26 +1,35 @@
-export async function request<TResponse>(
-  urlPart: string,
-  token?: string,
-  searchParams?: URLSearchParams
-): Promise<TResponse> {
+type HttpMethods = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+const buildRequestConfig = (method: HttpMethods, accessToken?: string, body?: BodyInit): RequestInit => {
+  const config: RequestInit = {};
+  config.method = method;
+  config.body = body instanceof FormData ? body : JSON.stringify(body);
+  config.headers = {
+    Accept: 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+    'content-type': 'application/json',
+  };
+
+  if (!accessToken) {
+    delete config.headers['Authorization'];
+  }
+
+  if (body instanceof FormData) {
+    delete config.headers['content-type'];
+  }
+
+  if (!body) {
+    delete config.body;
+  }
+
+  return config;
+};
+
+async function request<TResponse>(urlPart: string, config: RequestInit, searchParams?: URLSearchParams): Promise<TResponse> {
   const url =
     searchParams !== undefined
       ? `${process.env.NEXT_PUBLIC_QWACKER_API_URL}${urlPart}?${searchParams}`
       : `${process.env.NEXT_PUBLIC_QWACKER_API_URL}${urlPart}`;
-
-  const config: RequestInit =
-    token !== undefined && token !== ''
-      ? {
-          headers: {
-            'content-type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      : {
-          headers: {
-            'content-type': 'application/json',
-          },
-        };
 
   try {
     const response = await fetch(url, config);
@@ -32,12 +41,24 @@ export async function request<TResponse>(
 }
 
 export const qwackerApi = {
+  /*
+   * Sends an anonymous GET request to the qwacker api.
+   */
   getWithoutAuth: <TResponse>(urlPart: string, searchParams?: URLSearchParams) =>
-    request<TResponse>(urlPart, undefined, searchParams),
-  get: <TResponse>(urlPart: string, token: string, searchParams?: URLSearchParams) =>
-    request<TResponse>(urlPart, token, searchParams),
-
-  // todo: request Methode und quackerApi um Post erweitern
-  // Using `extends` to set a type constraint:
-  // post: <TBody extends BodyInit, TResponse>(url: string, body: TBody) => request<TResponse>(url, { method: 'POST', body }),
+    request<TResponse>(urlPart, buildRequestConfig('GET'), searchParams),
+  /*
+   * Sends a GET request to the qwacker api. An access token is required.
+   */
+  get: <TResponse>(urlPart: string, accessToken: string, searchParams?: URLSearchParams) =>
+    request<TResponse>(urlPart, buildRequestConfig('GET', accessToken), searchParams),
+  /*
+   * Sends a POST request to the qwacker api. An access token is required.
+   */
+  post: <TBody extends BodyInit, TResponse>(urlPart: string, accessToken: string, body: TBody) =>
+    request<TResponse>(urlPart, buildRequestConfig('POST', accessToken, body)),
+  /*
+   * Sends a POST request with a FormData body to the qwacker api. An access token is required.
+   */
+  postFormData: <TResponse>(urlPart: string, accessToken: string, body: FormData) =>
+    qwackerApi.post<FormData, TResponse>(urlPart, accessToken, body),
 };

--- a/src/services/qwacker-api/posts.ts
+++ b/src/services/qwacker-api/posts.ts
@@ -34,6 +34,7 @@ type QwackerMumbleResponse = {
 export type UploadImage = File & { preview: string };
 
 // todo: Eigener Typ für QueryParams
+// todo: Schreibweise params vereinheitlichen
 // todo: Neuer Type erstellen für ReturnType (count: number, mumbles: Mumble[]), da count benötigt wird
 export const fetchMumbles = async (params?: {
   token?: string;
@@ -64,35 +65,23 @@ export const fetchMumbles = async (params?: {
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const postMumble = async (text: string, file: UploadImage | null, accessToken?: string) => {
-  /*  if (!accessToken) {
-    throw new Error('No access token');
-  }
+// todo: Interface für CreateParameters
+export const postMumble = async (text: string, file: UploadImage | null, accessToken: string) => {
+  // todo: prüfen ob ein Text gesetzt ist
+  const formDataBody = new FormData();
+  formDataBody.append('text', text);
 
-  const formData = new FormData();
-  formData.append('text', text);
   if (file) {
-    formData.append('image', file);
+    formDataBody.append('image', file);
   }
-
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_QWACKER_API_URL}posts`, {
-      method: 'POST',
-      body: formData,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    if (!response.ok) {
-      throw new Error('Something was not okay');
-    }
-
-    return transformApiPostResultToMumble(await response.json());
+    const postResult = await qwackerApi.postFormData<Post>(`posts`, accessToken, formDataBody);
+    const mumble = await transformApiPostResultToMumble(postResult, accessToken);
+    return mumble;
   } catch (error) {
-    throw new Error(error instanceof Error ? error.message : 'Could not post mumble');
+    // todo: Handle any error happened.
+    throw new Error('Something was not okay');
   }
-  */
 };
 
 export const fetchMumbleById = async (id: string, accessToken: string) => {


### PR DESCRIPTION
- Funktionalität für POST-Requests (mit FormData und JSONData als Body) in der qwacker API ergänzt.
- Anwendung in der writeCard und im Posts Service ist noch nicht final. Da gibt es noch ein paar TODOs