### PR TITLE
perf: improve index rendering strategy

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -29,6 +29,9 @@ module.exports = {
           '\\.d\\.ts$', // TypeScript declaration files
           '(^|/)tsconfig\\.json$', // TypeScript config
           '(^|/)(babel|webpack)\\.config\\.(js|cjs|mjs|ts|json)$', // other configs
+          '(^|/)src/pages/api/auth/\\[...nextauth\\].ts', // Next.js file
+          '(^|/)src/pages/_document.tsx', // Next.js file
+          '(^|/)src/middleware.ts', // Next.js file
         ],
       },
       to: {},

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXT_PUBLIC_URL: ${{ secrets.NEXT_PUBLIC_URL }}
           NEXT_PUBLIC_QWACKER_API_URL: ${{ secrets.NEXT_PUBLIC_QWACKER_API_URL }}
           ZITADEL_ISSUER: ${{ secrets.ZITADEL_ISSUER }}
           ZITADEL_CLIENT_ID: ${{ secrets.ZITADEL_CLIENT_ID }}

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,11 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        source: '/index-public',
+        destination: '/',
+        permanent: true,
+      },
+      {
         source: '/mumble-public/:id',
         destination: '/mumble/:id',
         permanent: true,

--- a/src/components/cards/write-card.tsx
+++ b/src/components/cards/write-card.tsx
@@ -20,7 +20,7 @@ import {
   UserShortRepresentationLabelType,
   UserShortRepresentationProfilePictureSize,
 } from '@smartive-education/design-system-component-library-team-ost';
-import { useSession } from 'next-auth/react';
+import { JWT } from 'next-auth/jwt';
 import Image from 'next/image';
 import Link from 'next/link';
 import { ChangeEvent, FC, FormEvent, useState } from 'react';
@@ -44,6 +44,7 @@ type WriteCardProps = {
   fileinputError: string;
   handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
   isSubmitting: boolean;
+  jwtPayload: JWT;
 };
 
 type WriteCardVariantMap = {
@@ -62,6 +63,7 @@ const writeCardVariantMap: Record<WriteCardVariant, WriteCardVariantMap> = {
   },
 };
 
+// todo: eigener Typ
 export const WriteCard: FC<WriteCardProps> = ({
   form,
   variant,
@@ -71,9 +73,9 @@ export const WriteCard: FC<WriteCardProps> = ({
   fileinputError,
   handleSubmit,
   isSubmitting,
+  jwtPayload,
 }) => {
   const settings = writeCardVariantMap[variant] || writeCardVariantMap.inline;
-  const { data: session } = useSession();
   const [isOpenFileUpload, setIsOpenFileUpload] = useState(false);
 
   const submitClick = (e: FormEvent<HTMLFormElement>) => {
@@ -87,17 +89,17 @@ export const WriteCard: FC<WriteCardProps> = ({
   };
 
   return (
-    session && (
+    jwtPayload && (
       <Card borderRadiusType={settings.borderRadiusType} isInteractive={settings.isInteractive}>
         {variant === WriteCardVariant.main && (
           <div className="absolute -left-l top-m">
             <ProfilePicture
-              alt={session.user.username}
+              alt={jwtPayload.user.username}
               imageComponent={Image}
               width={80}
               height={80}
               size={ProfilePictureSize.m}
-              src={session.user.avatarUrl}
+              src={jwtPayload.user.avatarUrl}
             />
           </div>
         )}
@@ -106,16 +108,16 @@ export const WriteCard: FC<WriteCardProps> = ({
 
           {variant === WriteCardVariant.inline && (
             <UserShortRepresentation
-              alt={session.user.username}
-              displayName={`${session.user.firstname} ${session?.user.lastname}`}
-              hrefProfile={`../profile/${session.user.id}`}
+              alt={jwtPayload.user.username}
+              displayName={`${jwtPayload.user.firstname} ${jwtPayload?.user.lastname}`}
+              hrefProfile={`../profile/${jwtPayload.user.id}`}
               imageComponent={Image}
               imageComponentArgs={{ width: 50, height: 50 }}
               labelType={UserShortRepresentationLabelType.m}
               linkComponent={Link}
               profilePictureSize={UserShortRepresentationProfilePictureSize.s}
-              src={session.user.avatarUrl ?? ''}
-              username={session.user.username}
+              src={jwtPayload.user.avatarUrl ?? ''}
+              username={jwtPayload.user.username}
             />
             /* todo: Typ des src Props prüfen. avatarUrl ist aktuell nullable. Es muss jedoch zwingend eine src angegeben werden */
             /* todo: Muss der Displayname hier nochmals zusammengesetzt werden? */

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -55,7 +55,7 @@ export const Header: FC<HeaderProps> = () => {
         imageComponent={Image}
         imageComponentArgs={{ width: 50, height: 50 }}
         linkComponent={Link}
-        linkComponentArgs={{ href: `/profile/${session?.user.id}` }}
+        linkComponentArgs={{ href: `/profile/${session.user.id}` }}
         renderAsLink={true}
         src={session.user.avatarUrl as string}
       />

--- a/src/components/lists/mumble-list.tsx
+++ b/src/components/lists/mumble-list.tsx
@@ -22,20 +22,21 @@ import {
   TextButtonDisplayMode,
   TextButtonSize,
 } from '@smartive-education/design-system-component-library-team-ost';
+import { JWT } from 'next-auth/jwt';
 import { ChangeEvent, FC, FormEvent, useEffect, useReducer } from 'react';
 
 type MumbleListProps = {
-  mumbles: Mumble[];
-  count: number;
-  variant: MumbleCardVariant;
   canUpdate?: boolean;
+  count: number;
   creator?: string;
-  likesFilter?: boolean;
-  isWriteCardVisible?: boolean;
-  isReplyActionVisible?: boolean;
   isLikeActionVisible?: boolean;
-  accessToken?: string;
-  replyToPostId?: string;
+  isReplyActionVisible?: boolean;
+  isWriteCardVisible?: boolean;
+  jwtPayload?: JWT | null;
+  likesFilter?: boolean;
+  mumbles: Mumble[];
+  replyToMumbleId?: string;
+  variant: MumbleCardVariant;
 };
 
 export const MumbleList: FC<MumbleListProps> = (props: MumbleListProps) => {
@@ -121,15 +122,15 @@ export const MumbleList: FC<MumbleListProps> = (props: MumbleListProps) => {
     //todo: postMumble über next page/api aufrufen
     try {
       let newMumble: Mumble;
-      props.replyToPostId
+      props.replyToMumbleId
         ? (newMumble = await postReply({
-            accessToken: props.accessToken as string,
-            mumbleId: props.replyToPostId,
+            accessToken: props.jwtPayload?.accessToken as string,
+            mumbleId: props.replyToMumbleId,
             text: writeState.form.textinput,
             file: writeState.form.file,
           }))
         : (newMumble = await postMumble({
-            accessToken: props.accessToken as string,
+            accessToken: props.jwtPayload?.accessToken as string,
             text: writeState.form.textinput,
             file: writeState.form.file,
           }));
@@ -160,15 +161,16 @@ export const MumbleList: FC<MumbleListProps> = (props: MumbleListProps) => {
           </TextButton>
         </div>
       )}
-      {props.isWriteCardVisible && (
+      {props.isWriteCardVisible && props.jwtPayload && (
         <WriteCard
+          fileinputError={writeState.fileinputError}
           form={writeState.form}
           handleChange={handleWriteCardFormChange}
           handleFileChange={handleFileChange}
-          resetFileinputError={resetFileinputError}
-          fileinputError={writeState.fileinputError}
           handleSubmit={handleSubmit}
           isSubmitting={writeState.formIsSubmitting}
+          jwtPayload={props.jwtPayload}
+          resetFileinputError={resetFileinputError}
           variant={WriteCardVariant.main}
         />
       )}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,20 +8,24 @@ export async function middleware(req: NextRequest) {
   const { pathname, origin } = req.nextUrl;
 
   const res = NextResponse.next();
-  if (pathname !== '/') {
-    const token = await getToken({ req });
-    if (!token) {
-      // if user isn't logged in and path starts with mumble, rewrite to
-      // mumble-public isr page
-      if (pathname.startsWith('/mumble')) {
-        const id = pathname.split('/').pop();
-        return NextResponse.rewrite(`${origin}/mumble-public/${id}`);
-      }
-
-      const url = new URL(`/auth/login`, req.url);
-      url.searchParams.set('callbackUrl', pathname);
-      return NextResponse.redirect(url);
+  const jwtPayload = await getToken({ req });
+  if (!jwtPayload) {
+    // if user isn't logged in and path is index page, rewrite to
+    // index-public isr page
+    if (pathname === '/') {
+      return NextResponse.rewrite(`${origin}/index-public`);
     }
+
+    // if user isn't logged in and path starts with mumble, rewrite to
+    // mumble-public isr page
+    if (pathname.startsWith('/mumble')) {
+      const id = pathname.split('/').pop();
+      return NextResponse.rewrite(`${origin}/mumble-public/${id}`);
+    }
+
+    const url = new URL(`/auth/login`, req.url);
+    url.searchParams.set('callbackUrl', pathname);
+    return NextResponse.redirect(url);
   }
   return res;
 }

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -58,7 +58,7 @@ export default function Login() {
     <SplitScreenLayout>
       <>
         <Head>
-          <title>Mumble - Anmelden</title>
+          <title>Anmelden</title>
         </Head>
 
         <div className="w-full lg:w-4/5 2xl:w-1/2 p-xl">

--- a/src/pages/auth/logout.tsx
+++ b/src/pages/auth/logout.tsx
@@ -32,7 +32,7 @@ export default function Logout() {
     <SplitScreenLayout>
       <>
         <Head>
-          <title>Mumble - Abmelden</title>
+          <title>Abmelden</title>
         </Head>
 
         <div className="w-full lg:w-4/5 2xl:w-1/2 p-xl">

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -51,7 +51,7 @@ export default function Register() {
     <SplitScreenLayout>
       <>
         <Head>
-          <title>Mumble - Registrieren</title>
+          <title>Registrieren</title>
         </Head>
 
         {!session && (

--- a/src/pages/index-public.tsx
+++ b/src/pages/index-public.tsx
@@ -10,16 +10,14 @@ import {
   StackDirection,
   StackSpacing,
 } from '@smartive-education/design-system-component-library-team-ost';
-import { GetServerSideProps, GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
-import { getToken, JWT } from 'next-auth/jwt';
+import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import Head from 'next/head';
 
-type TimelinePageProps = {
-  jwtPayload: JWT;
+type TimelinePublicPage = {
   mumbleList: TMumbleList;
 };
 
-export default function TimelinePage(props: TimelinePageProps): InferGetServerSidePropsType<typeof getServerSideProps> {
+export default function TimelinePublicPage(props: TimelinePublicPage): InferGetStaticPropsType<typeof getStaticProps> {
   return (
     <MainLayout>
       <>
@@ -38,10 +36,9 @@ export default function TimelinePage(props: TimelinePageProps): InferGetServerSi
           <MumbleList
             canUpdate={true}
             count={props.mumbleList.count}
-            isLikeActionVisible={true}
+            isLikeActionVisible={false}
             isReplyActionVisible={true}
-            isWriteCardVisible={true}
-            jwtPayload={props.jwtPayload}
+            isWriteCardVisible={false}
             mumbles={props.mumbleList.mumbles}
             variant={MumbleCardVariant.timeline}
           />
@@ -51,14 +48,13 @@ export default function TimelinePage(props: TimelinePageProps): InferGetServerSi
   );
 }
 
-export const getServerSideProps: GetServerSideProps = async ({ req }: GetServerSidePropsContext) => {
-  const jwtPayload = (await getToken({ req })) as JWT;
-
-  const mumbleList = await fetchMumbles({ accessToken: jwtPayload.accessToken });
+export const getStaticProps: GetStaticProps = async () => {
+  const mumbleList = await fetchMumbles();
 
   return {
+    // value could change after some experience with numbers of users, available server power / capacity, etc.
+    revalidate: 5,
     props: {
-      jwtPayload,
       mumbleList,
     },
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,7 +25,7 @@ export default function TimelinePage(props: TimelinePageProps): InferGetStaticPr
     <MainLayout>
       <>
         <Head>
-          <title>Mumble - Timeline</title>
+          <title>Timeline</title>
         </Head>
         <div className="text-violet-600">
           <Heading headingLevel={HeadingSize.h1}>Willkommen auf Mumble</Heading>
@@ -37,14 +37,14 @@ export default function TimelinePage(props: TimelinePageProps): InferGetStaticPr
         </div>
         <Stack direction={StackDirection.col} spacing={StackSpacing.s} withDivider={true}>
           <MumbleList
-            accessToken={props.jwtPayload?.accessToken}
-            mumbles={props.mumbles}
-            count={props.count}
-            variant={MumbleCardVariant.timeline}
             canUpdate={true}
-            isWriteCardVisible={!!props.jwtPayload}
-            isReplyActionVisible={true}
+            count={props.count}
             isLikeActionVisible={!!props.jwtPayload}
+            isReplyActionVisible={true}
+            isWriteCardVisible={!!props.jwtPayload}
+            jwtPayload={props.jwtPayload}
+            mumbles={props.mumbles}
+            variant={MumbleCardVariant.timeline}
           />
         </Stack>
       </>

--- a/src/pages/mumble-public/[id].tsx
+++ b/src/pages/mumble-public/[id].tsx
@@ -18,25 +18,25 @@ export default function MumblePublicPage(props: MumblePublicPageProps): InferGet
     <MainLayout>
       <>
         <Head>
-          <title>Mumble - {props.mumble.id}</title>
+          <title>Mumble</title>
         </Head>
         <div className="bg-white">
           <MumbleCard
-            variant={MumbleCardVariant.detailpage}
+            isReplyActionVisible={false}
             mumble={props.mumble}
             onLikeClick={onLikeClick}
-            isReplyActionVisible={false}
+            variant={MumbleCardVariant.detailpage}
           />
           <Stack direction={StackDirection.col} spacing={StackSpacing.s} withDivider={true}>
             <MumbleList
-              count={props.replies.length}
-              mumbles={props.replies}
-              variant={MumbleCardVariant.response}
               canUpdate={false}
-              replyToPostId={props.mumble.id}
-              isWriteCardVisible={false}
-              isReplyActionVisible={true}
+              count={props.replies.length}
               isLikeActionVisible={false}
+              isReplyActionVisible={true}
+              isWriteCardVisible={false}
+              mumbles={props.replies}
+              replyToMumbleId={props.mumble.id}
+              variant={MumbleCardVariant.response}
             />
           </Stack>
         </div>
@@ -67,10 +67,6 @@ export const getStaticPaths = async (): Promise<{ paths: { params: { id: string 
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const id = context.params?.id as string;
-
-  if (!id) {
-    throw new Error('No id found');
-  }
 
   const [mumble, replies] = await Promise.all([fetchMumbleById(id), fetchRepliesByMumbleId(id)]);
 

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -2,9 +2,9 @@ import { MumbleCardVariant } from '@/components/cards/mumble-card';
 import MainLayout from '@/components/layouts/main-layout';
 import { LikesList } from '@/components/lists/likes-list';
 import { MumbleList } from '@/components/lists/mumble-list';
-import { fetchMumbles, searchMumbles } from '@/services/qwacker-api/posts';
+import { fetchMumbles } from '@/services/qwacker-api/posts';
 import { fetchUserById } from '@/services/qwacker-api/users';
-import { Mumble } from '@/types/mumble';
+import { MumbleList as TMumbleList } from '@/types/mumble';
 import { User } from '@/types/user';
 import {
   IconCheckmark,
@@ -29,16 +29,15 @@ import {
   UserShortRepresentationLabelType,
 } from '@smartive-education/design-system-component-library-team-ost';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import { getToken } from 'next-auth/jwt';
-import { useSession } from 'next-auth/react';
+import { getToken, JWT } from 'next-auth/jwt';
 import Head from 'next/head';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 
 type ProfilePageProps = {
-  count: number;
-  mumbles: Mumble[];
+  jwtPayload: JWT;
+  mumbleList: TMumbleList;
   user: User;
 };
 
@@ -49,14 +48,13 @@ enum ProfilePageStateTypes {
 
 export default function ProfilePage(props: ProfilePageProps): InferGetServerSidePropsType<typeof getServerSideProps> {
   const [postType, setPostType] = useState<ProfilePageStateTypes>(ProfilePageStateTypes.mumbles);
-  const { data: session } = useSession();
-  const isCurrentUser = props.user.id === session?.user.id;
+  const isCurrentUser = props.user.id === props.jwtPayload.user.id;
 
   return (
     <MainLayout>
       <>
         <Head>
-          <title>Mumble - {props.user.displayName}</title>
+          <title>Profile</title>
         </Head>
         <Stack direction={StackDirection.col} spacing={StackSpacing.s}>
           <div className="relative">
@@ -138,21 +136,22 @@ export default function ProfilePage(props: ProfilePageProps): InferGetServerSide
           )}
           {postType === ProfilePageStateTypes.mumbles ? (
             <MumbleList
-              count={props.count}
-              mumbles={props.mumbles}
-              variant={MumbleCardVariant.timeline}
-              creator={props.user.id}
               canUpdate={false}
+              count={props.mumbleList.count}
+              creator={props.user.id}
+              isLikeActionVisible={true}
+              isReplyActionVisible={true}
               isWriteCardVisible={false}
-              isReplyActionVisible={!!session}
-              isLikeActionVisible={!!session}
+              mumbles={props.mumbleList.mumbles}
+              variant={MumbleCardVariant.timeline}
             />
           ) : (
+            /* todo: Falscher Anwendungsfall der MumbleCardVariant */
             <LikesList
-              variant={MumbleCardVariant.timeline}
               creator={props.user.id}
-              isReplyActionVisible={!!session}
-              isLikeActionVisible={!!session}
+              isLikeActionVisible={true}
+              isReplyActionVisible={true}
+              variant={MumbleCardVariant.timeline}
             />
           )}
         </Stack>
@@ -162,33 +161,18 @@ export default function ProfilePage(props: ProfilePageProps): InferGetServerSide
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query: { id } }) => {
-  try {
-    const jwtPayload = await getToken({ req });
-    if (!jwtPayload || !jwtPayload.accessToken) {
-      throw new Error('No jwtPayload found');
-    }
-    if (!id) {
-      throw new Error('No id found');
-    }
+  const jwtPayload = (await getToken({ req })) as JWT;
 
-    const user = await fetchUserById(id as string, jwtPayload.accessToken);
-    const { count, mumbles } = await fetchMumbles({ creator: id as string, accessToken: jwtPayload.accessToken });
+  const [user, mumbleList] = await Promise.all([
+    fetchUserById(id as string, jwtPayload.accessToken),
+    fetchMumbles({ creator: id as string, accessToken: jwtPayload.accessToken }),
+  ]);
 
-    return {
-      props: {
-        user,
-        count,
-        mumbles,
-      },
-    };
-  } catch (error) {
-    let message;
-    if (error instanceof Error) {
-      message = error.message;
-    } else {
-      message = String(error);
-    }
-
-    return { props: { error: message, user: '' } };
-  }
+  return {
+    props: {
+      jwtPayload,
+      mumbleList,
+      user,
+    },
+  };
 };


### PR DESCRIPTION
- nextjs dependency-cruiser warnings deaktiviert
- NEXT_PUBLIC_URL für share button deployt
- WriteCard um jwtPayload Prop erweitert. Wird jwtPayload, welches serverseitig bereitgestellt wird, anstelle des useSession-Hooks verwendet, welcher clientseitig agiert, gibt es kein layout shift bei der card.
- rendering strategy der timeline verbessert